### PR TITLE
fix: the state of the tabs will change when any of its properties change dynamically

### DIFF
--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -9,7 +9,11 @@ interface PrivateProps {
   variant?: 'primary' | 'secondary'
 }
 
-interface Props extends React.HTMLAttributes<HTMLButtonElement> {
+interface Props
+  extends React.DetailedHTMLProps<
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    HTMLButtonElement
+  > {
   textColor?: string
   disabledText?: string
   label: string

--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -57,7 +57,7 @@ function Tab({
       list.push(disabled ? 'text-gray-300' : 'text-gray-500')
     }
     return list.join(' ')
-  }, [value, variant])
+  }, [value, variant, disabled])
 
   return (
     <button

--- a/src/components/Tabs/TabGroup.tsx
+++ b/src/components/Tabs/TabGroup.tsx
@@ -142,7 +142,15 @@ function TabGroup({
       }
       return child
     })
-  }, [value, onClick, disabledText, childClassName, textColor, variant])
+  }, [
+    value,
+    onClick,
+    disabledText,
+    childClassName,
+    textColor,
+    variant,
+    children
+  ])
 
   useEffect(() => {
     handleChangeIndicator(value)


### PR DESCRIPTION
## Summary

The state of the tabs did not change when any of their properties changed dynamically

Closes #46
Closes #45

## Task

[CD-830](https://dd360.atlassian.net/browse/CD-830)


## Affected sections

- src/components/Tabs/Tab.tsx
- src/components/Tabs/TabGroup.tsx

## How did you test this change?

all test passed ✅
