### PR TITLE
fix: add optional theme, use lightTheme by default

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,5 @@
 import '../src/dd360.css'
-import { ThemeProvider, createTheme } from '../src/theme'
+import { ThemeProvider } from '../src/theme'
 
 export const parameters = {
     actions: { argTypesRegex: '^on[A-Z].*' },
@@ -11,14 +11,9 @@ export const parameters = {
     }
 }
 
-const theme = createTheme({ palette: { primary: {main: 'purple'} }, typography: {
-    fontFamily: `'Delicious Handrawn', sans-serif`,
-    srcFont: 'https://fonts.googleapis.com/css2?family=Delicious+Handrawn&display=swap'
-} })
-
 export const decorators = [
     (Story) => (
-        <ThemeProvider theme={theme}>
+        <ThemeProvider>
             <Story />
         </ThemeProvider>
     ),

--- a/src/theme/shared.ts
+++ b/src/theme/shared.ts
@@ -4,7 +4,7 @@ import { DEFAULT_TAILWIND_TEXT_SIZE } from '../lib/font'
 // Define the props for the ThemeProvider component
 export interface ThemeProviderProps {
   children: ReactNode // The children that the ThemeProvider wraps
-  theme: ThemeProps // The theme object that provides styling for the children
+  theme?: ThemeProps // The theme object that provides styling for the children
 }
 
 // Define the optional properties for a color palette option
@@ -59,11 +59,11 @@ export interface ThemeProps {
 }
 
 // Defining the default light mode theme
-const lightModeTheme: ThemeProps = {
+export const lightModeTheme: ThemeProps = {
   palette: {
     primary: {
       contrastText: 'white',
-      main: 'var(--primary)'
+      main: '#1c4ed9'
     },
     secondary: {
       main: 'white',
@@ -85,6 +85,9 @@ const lightModeTheme: ThemeProps = {
     textColor: '#000'
   },
   typography: {
+    fontFamily: 'Archivo',
+    srcFont:
+      'https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;700&display=swap',
     h1: {
       fontSize: DEFAULT_TAILWIND_TEXT_SIZE['4xl']
     },


### PR DESCRIPTION
## Summary

The ThemeProvider was updated so that the theme was optional, and thus take the lightTheme from the library by default

## Task

No yet

## Affected sections

```
.storybook/preview.js
src/theme/ThemeProvider.tsx
src/theme/shared.ts
```

## How did you test this change?

already tested
