### PR TITLE
fix(Modal): Position modal

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -44,7 +44,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
     const [isClose, setClose] = useState<boolean>(false)
 
     const containerClasses = composeClasses(
-      'top-0 w-full z-50 transition duration-1000 ease-in delay-1500 h-screen',
+      'top-0 left-0 right-0 bottom-0 w-full z-50 transition duration-1000 ease-in delay-1500 h-screen',
       blur && 'blur-sm',
       !isClose ? 'hidden' : 'fixed'
     )


### PR DESCRIPTION
## Summary

Positions were added for the correct functioning of the modal since if it was inside a component with a margin, the modal also took that margin

`Before:`

![imagen](https://user-images.githubusercontent.com/127886190/232084085-a33232cb-ac33-46c3-8472-5fbaec85c995.png)

`Now:`

![imagen](https://user-images.githubusercontent.com/127886190/232084203-efc50678-1e00-493e-aefb-f1fd717aff37.png)


## Task

- Not yet


## Affected sections

- src/components/Modal/Modal.tsx

## How did you test this change?

- Mannualy
