### PR TITLE
fix: enable darkMode in tailwindcss config

### DIFF
--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -10,13 +10,13 @@ export function ThemeProvider({
   theme = lightModeTheme
 }: ThemeProviderProps) {
   useEffect(() => {
-    new LoanTheme(theme)
+    new LoadTheme(theme)
   }, [theme])
 
   return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
 }
 
-class LoanTheme {
+class LoadTheme {
   private rootStyle: HTMLStyleElement | null = null
   private rootProperties: { [key: string]: string } = {}
   private fontFace = ''

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,7 @@ module.exports = {
   purge: {
     content: ['./src/**/*.{js,jsx,ts,tsx}']
   },
-  darkMode: false, // or 'media' or 'class'
+  darkMode: 'class',
   theme: {
     fontFamily: {
       sans: ['var(--fontFamily)', ...defaultTheme.fontFamily.sans]


### PR DESCRIPTION
## Summary

🧨 Activating this configuration we can make use of the dark mode classes in our tailwind css classes

## Task

No Yet

## Affected sections

src/theme/ThemeProvider.tsx
tailwind.config.js

## How did you test this change?

<img width="381" alt="Screen Shot 2023-04-14 at 10 17 58 a m" src="https://user-images.githubusercontent.com/31332180/232100033-61557c3e-5e9b-4ace-bf7b-227b482f582e.png">

