### PR TITLE
feat: AsideModal component was added to package

### DIFF
--- a/exports.json
+++ b/exports.json
@@ -195,6 +195,11 @@
       "require": "./dist/cjs/components/Anchor/index.js",
       "module": "./dist/esm/components/Anchor/index.js",
       "default": "./dist/esm/components/Anchor/index.js"
+    },
+    "./AsideModal": {
+      "require": "./dist/cjs/components/AsideModal/index.js",
+      "module": "./dist/esm/components/AsideModal/index.js",
+      "default": "./dist/esm/components/AsideModal/index.js"
     }
   },
   "typesVersions": {
@@ -236,7 +241,8 @@
       "Select": ["./dist/esm/components/Form/Select.d.ts"],
       "TextArea": ["./dist/esm/components/Form/TextArea.d.ts"],
       "Layout": ["./dist/esm/components/Layout/index.d.ts"],
-      "Anchor": ["./dist/esm/components/Anchor/index.d.ts"]
+      "Anchor": ["./dist/esm/components/Anchor/index.d.ts"],
+      "AsideModal": ["./dist/esm/components/AsideModal/index.d.ts"]
     }
   }
 }

--- a/src/components/AsideModal/AsideModal.test.tsx
+++ b/src/components/AsideModal/AsideModal.test.tsx
@@ -1,0 +1,37 @@
+import { vi, describe, afterEach } from 'vitest'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+
+import AsideModal from './AsideModal'
+
+const props = {
+  title: 'Test Title',
+  open: true,
+  onClose: vi.fn(),
+  disableEscapeKeyDown: false,
+  children: <div>Test Content</div>
+}
+
+const renderComponent = () => {
+  return render(<AsideModal {...props} />)
+}
+
+describe('AsideModal', () => {
+  afterEach(cleanup)
+
+  it('should be render with props', () => {
+    const { getByRole, getByText } = renderComponent()
+
+    expect(getByRole('aside-modal')).toBeDefined()
+    expect(getByText('Test Title')).toBeDefined()
+    expect(getByText('Test Content')).toBeDefined()
+  })
+
+  it('should calls onClose callback when close button is clicked', () => {
+    const { getByRole } = renderComponent()
+
+    const btnClose = getByRole('btn-close')
+    fireEvent.click(btnClose)
+
+    expect(props.onClose).toHaveBeenCalled()
+  })
+})

--- a/src/components/AsideModal/AsideModal.tsx
+++ b/src/components/AsideModal/AsideModal.tsx
@@ -1,0 +1,97 @@
+import {
+  ComponentProps,
+  FC,
+  MutableRefObject,
+  ReactNode,
+  useEffect,
+  useRef
+} from 'react'
+import { XCircleIcon } from '@heroicons/react/outline'
+import { composeClasses } from 'lib/classes'
+import { useModalManager } from 'hooks'
+import Text, { TextVariantType } from '../Typography'
+
+export interface IAsideModalProps extends ComponentProps<'aside'> {
+  /**
+   * This prop is used to set the title of the modal.
+   * It expects a string that represents the title to be displayed in the modal.
+   */
+  title: string
+  /**
+   * This prop is used to set the variant of the title in the modal.
+   * It expects a value of TextVariantType type that represents the variant of the title displayed in the modal.
+   */
+  titleVariant?: TextVariantType
+  /**
+   * This prop is used to control whether the modal is open or closed.
+   * It expects a boolean value (true or false) that determines whether the modal is open (true) or closed (false).
+   */
+  open: boolean
+  /**
+   * This prop is used to provide a callback function that will be executed when the modal is closed.
+   * It expects a function that takes no arguments and returns no value (void).
+   */
+  onClose: () => void
+  /**
+   * This prop is optional (default false) and is used to control whether the ability to close the modal by pressing the Escape key is disabled or enabled.
+   * It expects a boolean value (true or false) that determines whether the Escape key closing function is enabled (false) or disabled (true)
+   */
+  disableEscapeKeyDown?: boolean
+  /**
+   * This prop is used to pass a children
+   */
+  children: ReactNode
+}
+
+const AsideModal: FC<IAsideModalProps> = ({
+  title,
+  titleVariant = 'h4',
+  open,
+  onClose,
+  disableEscapeKeyDown,
+  children,
+  ...otherProps
+}) => {
+  const { isOpen, handleModalClose } = useModalManager({
+    open,
+    onClose,
+    disableEscapeKeyDown
+  })
+
+  const asideModalRef: MutableRefObject<HTMLDivElement | null> =
+    useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!asideModalRef.current) return
+    asideModalRef.current.style.maxHeight = `calc(100vh - ${asideModalRef.current.offsetTop}px)`
+  }, [isOpen])
+
+  return (
+    <aside
+      role="aside-modal"
+      className={composeClasses(
+        isOpen ? 'translate-x-0' : 'translate-x-full',
+        'fixed top-20 right-0 w-full lg:w-8/12 max-w-5xl h-full px-10 py-7 border-t-0 shadow-lg',
+        'bg-white overflow-auto transform transition-all duration-300 ease-linear z-40'
+      )}
+      ref={asideModalRef}
+      {...otherProps}
+    >
+      <div className="flex justify-between items-center">
+        <Text variant={titleVariant} bold>
+          {title}
+        </Text>
+        <div
+          role="btn-close"
+          className="text-info cursor-pointer hover:text-primary transition ease-in-out duration-300"
+          onClick={handleModalClose}
+        >
+          <XCircleIcon className="w-6" />
+        </div>
+      </div>
+      {children}
+    </aside>
+  )
+}
+
+export default AsideModal

--- a/src/components/AsideModal/index.ts
+++ b/src/components/AsideModal/index.ts
@@ -1,0 +1,3 @@
+import AsideModal from './AsideModal'
+export default AsideModal
+export * from './AsideModal'

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -7,7 +7,7 @@ export interface AvatarProps extends React.ImgHTMLAttributes<HTMLImageElement> {
 }
 
 const Avatar = forwardRef<HTMLImageElement, AvatarProps>(
-  ({ children, src, alt, className, ...props }: AvatarProps, ref) => {
+  ({ children, src, alt, className, ...props }, ref) => {
     if (children) {
       return (
         <div

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,25 +1,68 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useState,
-  forwardRef
-} from 'react'
+import { forwardRef } from 'react'
+import { useModalManager } from 'hooks'
 import { composeClasses } from 'lib/classes'
 import './modal.css'
 
 export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Required.
+   * This prop indicates if the modal is active or not.
+   */
   active: boolean
+  /**
+   * Optional.
+   * This prop indicates if an animation should be applied to the modal.
+   */
   animation?: boolean
+  /**
+   * Optional.
+   * This prop defines the height of the modal's background.
+   */
   bgHeight?: string
+  /**
+   * Optional.
+   * This prop indicates if a blur effect should be applied to the modal's background.
+   */
   blur?: boolean
+  /**
+   * Optional.
+   * Prop to assign additional CSS classes to the modal.
+   */
   className?: string
+  /**
+   * Optional.
+   * Prop to assign additional CSS classes to the modal.
+   */
   fullScreen?: boolean
+  /**
+   * Optional.
+   * This prop defines the height of the modal.
+   */
   height?: string
+  /**
+   * Optional.
+   * This prop defines the maxHeight of the modal.
+   */
   maxHeight?: string
+  /**
+   * Optional.
+   * This prop indicates if a dark overlay should be shown behind the modal.
+   */
   overlay?: boolean
+  /**
+   * Optional.
+   * This prop indicates if the modal should prevent closing.
+   */
   preventClose?: boolean
+  /**
+   * Required.
+   * This prop indicates callback that is executed when the modal is closed.
+   */
   setCloseModal: () => void
+  /**
+   * Optional.
+   * This prop defines the width of the modal.
+   */
   width?: string
 }
 
@@ -41,12 +84,16 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
     }: ModalProps,
     ref
   ) => {
-    const [isClose, setClose] = useState<boolean>(false)
+    const { isOpen, handleModalClose } = useModalManager({
+      open: active,
+      onClose: setCloseModal,
+      preventClose
+    })
 
     const containerClasses = composeClasses(
       'top-0 left-0 right-0 bottom-0 w-full z-50 transition duration-1000 ease-in delay-1500 h-screen',
       blur && 'blur-sm',
-      !isClose ? 'hidden' : 'fixed'
+      !isOpen ? 'hidden' : 'fixed'
     )
 
     const dynamicClassName = composeClasses(
@@ -56,29 +103,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
       className
     )
 
-    const handleClose = useCallback(() => {
-      setClose(false)
-      setCloseModal()
-    }, [])
-
-    const handleKeyUp = useCallback((event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        handleClose()
-      }
-    }, [])
-
-    useLayoutEffect(() => {
-      document.addEventListener('keyup', handleKeyUp)
-      return () => {
-        document.removeEventListener('keyup', handleKeyUp)
-      }
-    }, [])
-
-    useEffect(() => {
-      setClose(active)
-    }, [active])
-
-    if (!isClose) return null
+    if (!isOpen) return null
 
     return (
       <>
@@ -89,7 +114,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
           style={{
             backgroundColor: overlay && !blur ? 'rgba(17, 24, 39, 0.75)' : ''
           }}
-          onClick={() => !preventClose && handleClose()}
+          onClick={handleModalClose}
           {...props}
         >
           <div className="flex items-center justify-center h-full">
@@ -104,7 +129,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
             >
               <div
                 role="btn-close"
-                onClick={handleClose}
+                onClick={handleModalClose}
                 className="absolute top-0 right-0  mr-6 cursor-pointer mt-6"
               >
                 <svg

--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -8,6 +8,21 @@ import React, {
 import { format } from 'dd360-utils'
 import { composeClasses } from 'lib'
 
+export type TextVariantType =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'p'
+  | 'span'
+  | 'small'
+  | 'label'
+  | 'a'
+  | 'currency'
+  | 'anchorSmall'
+
 export type TextSizeType =
   | '9xl'
   | '8xl'
@@ -34,20 +49,7 @@ type TResponsiveText = {
 export interface TextProps extends DetailedHTMLProps<HTMLAttributes<any>, any> {
   children?: React.ReactNode
   className?: string
-  variant?:
-    | 'h1'
-    | 'h2'
-    | 'h3'
-    | 'h4'
-    | 'h5'
-    | 'h6'
-    | 'p'
-    | 'span'
-    | 'small'
-    | 'label'
-    | 'a'
-    | 'currency'
-    | 'anchorSmall'
+  variant?: TextVariantType
   align?: 'center' | 'left' | 'right' | 'justify'
   bold?: boolean
   fontBold?: 'bold' | 'medium'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,6 +13,9 @@ export * from './Typography/Text'
 export { default as Modal } from './Modal'
 export * from './Modal'
 
+export { default as AsideModal } from './AsideModal'
+export * from './AsideModal'
+
 export { default as Breadcrumbs } from './Breadcrumbs'
 export * from './Breadcrumbs'
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,7 @@
 export { default as useResize } from './useResize'
-export { usePagination } from './usePagination'
 export * from './useResize'
+
+export { default as useModalManager } from './useModalManager'
+export * from './useModalManager'
+
+export { usePagination } from './usePagination'

--- a/src/hooks/useModalManager.ts
+++ b/src/hooks/useModalManager.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect, useCallback } from 'react'
+
+export interface IParamsConfigModal {
+  open: boolean
+  onClose: () => void
+  disableEscapeKeyDown?: boolean
+  preventClose?: boolean
+}
+
+export default function useModalManager(params: IParamsConfigModal) {
+  const {
+    open,
+    onClose,
+    disableEscapeKeyDown = false,
+    preventClose = false
+  } = params
+  const [isOpen, setIsOpen] = useState<boolean>(false)
+
+  function handleModalClose() {
+    if (preventClose) return
+    setIsOpen(false)
+    onClose()
+  }
+
+  const escDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (!disableEscapeKeyDown && event.key === 'Escape') {
+        handleModalClose()
+      }
+    },
+    [disableEscapeKeyDown, handleModalClose]
+  )
+
+  useEffect(() => {
+    setIsOpen(open)
+  }, [open])
+
+  useEffect(() => {
+    if (!isOpen) return
+    document.addEventListener('keydown', escDown)
+    return () => {
+      document.removeEventListener('keydown', escDown)
+    }
+  }, [disableEscapeKeyDown, handleModalClose])
+
+  return { isOpen, handleModalClose }
+}

--- a/src/stories/AsideModal.stories.tsx
+++ b/src/stories/AsideModal.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import Button from '../components/Buttons/Button'
+import AsideModal from '../components/AsideModal'
+
+export default {
+  title: 'Modals/AsideModal',
+  component: AsideModal
+} as ComponentMeta<typeof AsideModal>
+
+const Template: ComponentStory<typeof AsideModal> = ({
+  open: _open,
+  onClose: _onClose,
+  title,
+  children,
+  ...otherArgs
+}) => {
+  const [open, setOpen] = React.useState(false)
+  const handleOpen = () => setOpen(true)
+  const handleClose = () => setOpen(false)
+
+  return (
+    <>
+      <Button onClick={handleOpen}>Open Modal</Button>
+      <AsideModal
+        open={open}
+        onClose={handleClose}
+        title={title}
+        children={children}
+        {...otherArgs}
+      />
+    </>
+  )
+}
+
+export const AsideModalTemplate = Template.bind({})
+AsideModalTemplate.args = {
+  children: 'Aside modal children',
+  title: 'Aside modal title'
+}

--- a/src/stories/ModalCustom.stories.tsx
+++ b/src/stories/ModalCustom.stories.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
+
+import Button from '../components/Buttons/Button'
 import ModalCustomComponent from '../components/Modal'
 
 export default {
@@ -7,13 +9,33 @@ export default {
   component: ModalCustomComponent
 } as ComponentMeta<typeof ModalCustomComponent>
 
-const Template: ComponentStory<typeof ModalCustomComponent> = (args) => (
-  <ModalCustomComponent {...args} />
-)
+const Template: ComponentStory<typeof ModalCustomComponent> = ({
+  active: _open,
+  setCloseModal: _onClose,
+  title,
+  children,
+  ...otherArgs
+}) => {
+  const [open, setOpen] = React.useState(false)
+  const handleOpen = () => setOpen(true)
+  const handleClose = () => setOpen(false)
+
+  return (
+    <>
+      <Button onClick={handleOpen}>Open Modal</Button>
+      <ModalCustomComponent
+        active={open}
+        setCloseModal={handleClose}
+        title={title}
+        children={children}
+        {...otherArgs}
+      />
+    </>
+  )
+}
 
 export const Modal = Template.bind({})
 Modal.args = {
-  active: true,
   blur: false,
   children: (
     <>

--- a/src/stories/ProgressCircle.stories.tsx
+++ b/src/stories/ProgressCircle.stories.tsx
@@ -5,7 +5,7 @@ import ProgressCircleComponent from '../components/ProgressCircle'
 export default {
   title: 'Controls/ProgressCircular',
   component: ProgressCircleComponent
-} as ComponentMeta<typeof ProgressCircular>
+} as ComponentMeta<typeof ProgressCircleComponent>
 
 const Template: ComponentStory<typeof ProgressCircleComponent> = (args) => (
   <ProgressCircleComponent {...args} />


### PR DESCRIPTION
## Summary

This PR can be related with:

- AsideModal component was added to library
- Add hook to reuse logic of the modal's
- Refactorized `Modal` component to use hook `useModalManager`
- Export variant of `TextComponent`

## Task

Not yet

## How did you test this change?
- Mannualy with storybook
- All tests was passed ✅ 
