### PR TITLE
fix(Modal): fixed position modal

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -97,7 +97,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
     )
 
     const dynamicClassName = composeClasses(
-      'absolute z-50 flex-wrap text-center flex drop-shadow-lg bg-white bottom-0 rounded-t-2xl',
+      'absolute z-50 flex-wrap text-center flex drop-shadow-lg bg-white rounded-t-2xl',
       'md:bottom-auto md:w-auto md:rounded-2xl md:mb-6 md:mt-6',
       animation && 'animation-modal',
       className


### PR DESCRIPTION
## Summary

The "bottom-0" position in the className was removed

`With bottom-0:`

![imagen](https://user-images.githubusercontent.com/127886190/232607857-46d64c82-2668-4743-8772-d0907a7ea81b.png)

`Without bottom-0:`

![imagen](https://user-images.githubusercontent.com/127886190/232607978-29ca359c-eb36-4859-a98e-90b948cc9a79.png)


## Task

- Not yet


## Affected sections

- src/components/Modal/Modal.tsx

## How did you test this change?

- Mannualy
