### PR TITLE
Feat: list of pagination options based on the number of total elements

### DIFF
--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -5,6 +5,7 @@ import Pagination, { PaginationProps } from './Pagination'
 
 const defaultProps: PaginationProps = {
   totalPages: 10,
+  totalRows: 30,
   currentPage: 1,
   sliceSize: '5',
   firstText: 'Show',
@@ -150,6 +151,23 @@ describe('<Pagination/>', () => {
       )
       const items = getAllByRole('list-page') as HTMLDivElement[]
       expect(items).toHaveLength(4)
+    })
+  })
+
+  describe('options in the select element', () => {
+    it('should have a maximum option value equal to or less than totalRows', () => {
+      const { getByRole, getAllByRole } = render(
+        <Pagination {...defaultProps} />
+      )
+      const select = getByRole('select-slice-size') as HTMLSelectElement
+      const options = getAllByRole('option') as HTMLOptionElement[]
+      fireEvent.change(select, { target: { value: defaultProps.totalRows } })
+      const maxOptionValue = Math.max(
+        ...options.map((option) => parseInt(option.value, 10))
+      )
+      expect(select).toBeDefined()
+      expect(select.value).toBe(`${defaultProps.totalRows}`)
+      expect(maxOptionValue).toEqual(defaultProps.totalRows)
     })
   })
 })

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -9,24 +9,26 @@ import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/outline'
 import { composeClasses } from 'lib/classes'
 import Text from '../Typography'
 
+type Pages =
+  | '5'
+  | '10'
+  | '15'
+  | '20'
+  | '25'
+  | '30'
+  | '35'
+  | '40'
+  | '45'
+  | '50'
+  | '55'
+  | '60'
+  | '65'
+
 export interface PaginationProps {
   totalPages: number
-  totalRows?: number
   currentPage: number
-  sliceSize?:
-    | '5'
-    | '10'
-    | '15'
-    | '20'
-    | '25'
-    | '30'
-    | '35'
-    | '40'
-    | '45'
-    | '50'
-    | '55'
-    | '60'
-    | '65'
+  sliceSize?: Pages
+  totalRows?: number
   firstText?: string
   secondText?: string
   goToPreviousPage: () => void
@@ -40,7 +42,7 @@ const buttonStyle =
 
 const Pagination = ({
   totalPages,
-  totalRows = 40,
+  totalRows,
   currentPage,
   sliceSize,
   firstText,
@@ -51,6 +53,10 @@ const Pagination = ({
   setSize
 }: PaginationProps) => {
   const [selectSliceSize, setSelectSliceSize] = useState(sliceSize)
+  const totalItems = useMemo(() => {
+    if (totalRows) return totalRows
+    return totalPages * Number(sliceSize)
+  }, [totalRows, totalPages, sliceSize])
 
   const pages = useMemo(() => {
     const pagesList = new Array(totalPages).fill(0).map((_, index) => index + 1)
@@ -66,22 +72,22 @@ const Pagination = ({
 
   const options = useMemo(() => {
     const optionList = []
-    for (let i = 5; i <= totalRows; i += 5) {
+    for (let i = 5; i <= totalItems; i += 5) {
       optionList.push(i)
     }
 
     // make sure the last value is in the option list
-    if (optionList[optionList.length - 1] !== totalRows) {
-      optionList.push(totalRows)
+    if (optionList[optionList.length - 1] !== totalItems) {
+      optionList.push(totalItems)
     }
 
     return optionList
-  }, [totalRows])
+  }, [totalItems])
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       setSize(Number(e.target.value))
-      setSelectSliceSize(e.target.value as any)
+      setSelectSliceSize(e.target.value as Pages)
     },
     []
   )
@@ -108,10 +114,10 @@ const Pagination = ({
           className="w-12 pl-2 mr-2 outline-none text-primary bg-transparent"
           onChange={(e) => handleChange(e)}
         >
-          {options.map((option) => {
+          {options.map((opt) => {
             return (
-              <option role="option" key={option} value={option}>
-                {option}
+              <option role="option" key={opt} value={opt}>
+                {opt}
               </option>
             )
           })}

--- a/src/stories/Pagination.stories.tsx
+++ b/src/stories/Pagination.stories.tsx
@@ -15,6 +15,7 @@ const mockFn = (text: string) => alert(text)
 
 export const Pagination = Template.bind({})
 Pagination.args = {
+  totalRows: 30,
   totalPages: 10,
   currentPage: 1,
   sliceSize: '5' as any,


### PR DESCRIPTION
## Summary

Previously, the page component was putting a fixed number of options from which the list of elements was cut despite the fact that the total number of elements was less than that list, with this change what is done is that the list of options of cut are made from the number of totalRows so that it does not create more options than they need and in this way make the user see the maximum number of available elements and no more.

<img width="563" alt="Screen Shot 2023-05-02 at 10 09 58 p m" src="https://user-images.githubusercontent.com/31332180/235831443-40ab1180-5f93-4387-a322-de48755c61ad.png">

## Task

- [LEN-649](https://dd360.atlassian.net/browse/LEN-649)

## Affected sections

```
src/components/Pagination/Pagination.test.tsx
src/components/Pagination/Pagination.tsx
src/stories/Pagination.stories.tsx
```

## How did you test this change?
<img width="431" alt="Screen Shot 2023-05-02 at 10 07 26 p m" src="https://user-images.githubusercontent.com/31332180/235831130-9fb26a56-b6fd-40b6-b3c6-077b51531971.png">
