### PR TITLE
fix: add missing optional params on useTooltip

### DIFF
--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -5,7 +5,7 @@ import {
   render,
   RenderResult
 } from '@testing-library/react'
-import { beforeEach, describe, it } from 'vitest'
+import { beforeEach, describe, it, vi } from 'vitest'
 import { TabGroup, Tab, TabPanel, TabGroupProps } from './index'
 
 const defaultProps: TabGroupProps = {
@@ -48,6 +48,8 @@ const BasicTabs = (props: TabGroupProps) => {
     </div>
   )
 }
+
+window.HTMLElement.prototype.scrollIntoView = vi.fn()
 
 describe('<TabGroup /> variant="primary ', () => {
   it('Indication bar is renderer: orientation="horizontal"', () => {

--- a/src/hooks/useTooltip.ts
+++ b/src/hooks/useTooltip.ts
@@ -35,11 +35,9 @@ const useIsMounted = () => {
  * - `handleClick`: A function to handle the click event on the tooltip trigger element
  * - `refs`: An object containing three references
  */
-export default function useTooltip({
-  placement = 'top',
-  showDelay = 100,
-  hideDelay = 100
-}: TooltipParams) {
+export default function useTooltip(params?: TooltipParams) {
+  const { placement = 'top', showDelay = 100, hideDelay = 100 } = params || {}
+
   const isMounted = useIsMounted()
   const [isVisible, setIsVisible] = useState<boolean>(false)
   const refElement = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
## Summary
In this MR:

- change parameters to optionals on `useTooltip`
- remove unnecesary logs of scroll on `Tabs`

## Task
[CD-1028](https://dd360.atlassian.net/browse/CD-1028?atlOrigin=eyJpIjoiMTIxMGY1OWQ5NDc0NDk3ZjhiYTg5YTMxOTc4MTZlMDkiLCJwIjoiaiJ9)

## How did you test this change?
All tests was passed ✅ 
