### PR TITLE
fix: The default of the children prop of the text component was changed

### DIFF
--- a/src/components/Typography/Text.tsx
+++ b/src/components/Typography/Text.tsx
@@ -189,7 +189,7 @@ const Text: FC<TextProps> = forwardRef<HTMLElement, TextProps>(
 
 Text.displayName = 'Text'
 Text.defaultProps = {
-  children: undefined,
+  children: '',
   variant: undefined,
   size: undefined,
   align: undefined,


### PR DESCRIPTION
## Summary

The default of the children prop of the text component was changed

## Task

- Not yet

## Affected sections

- src/components/Typography/Text.tsx

## How did you test this change?

- Mannualy 
- All tests was passed ✅


