### PR TITLE
fix: add a z-index to the sidebar to overlay it

### DIFF
--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -198,7 +198,7 @@ const SideBar = ({
         ref={sidebarRef}
         role="container-sidebar"
         className={composeClasses(
-          'bg-gray-50 shadow-lg border-t-0 box-border overflow-hidden h-full fixed',
+          'bg-gray-50 shadow-lg border-t-0 box-border overflow-hidden h-full fixed z-40',
           'transition-all delay-75 duration-200 ease-in',
           expand ? 'w-60' : 'w-0 lg:w-14'
         )}


### PR DESCRIPTION
## Summary

Add a z-index to the sidebar to overlay it

## Task

[CD-1049](https://dd360.atlassian.net/browse/CD-1049)


## Affected sections

- src/components/SideBar/SideBar.tsx

## How did you test this change?

All test passed ✅
