### PR TITLE
refactor: for mobile devices, the sidebar will overlay the content

### DIFF
--- a/src/components/SideBar/SideBar.test.tsx
+++ b/src/components/SideBar/SideBar.test.tsx
@@ -156,15 +156,15 @@ describe('<SideBar/>', () => {
   })
 
   it('rotate expand button when it is clicked', () => {
-    const btnExpand = renderResult.getByRole('active-sidebar')
+    let btnExpand = renderResult.getByRole('active-sidebar')
 
     fireEvent.click(btnExpand)
     vi.advanceTimersByTime(300)
 
-    const btnExpand2 = renderResult.getByRole('active-sidebar')
+    btnExpand = renderResult.getByRole('active-sidebar')
 
     expect(
-      (btnExpand2.firstChild as HTMLElement).className.includes('rotate-0')
+      (btnExpand.firstChild as HTMLElement).className.includes('rotate-0')
     ).toBeTruthy()
   })
 

--- a/src/components/SideBar/SideBar.test.tsx
+++ b/src/components/SideBar/SideBar.test.tsx
@@ -161,8 +161,10 @@ describe('<SideBar/>', () => {
     fireEvent.click(btnExpand)
     vi.advanceTimersByTime(300)
 
+    const btnExpand2 = renderResult.getByRole('active-sidebar')
+
     expect(
-      (btnExpand.firstChild as HTMLElement).className.includes('rotate-0')
+      (btnExpand2.firstChild as HTMLElement).className.includes('rotate-0')
     ).toBeTruthy()
   })
 

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -104,6 +104,10 @@ export interface SideBarProps {
    * Number of items of type skeletons to show when isLoadingSideBarList is true
    */
   numSkeletons?: number
+  /**
+   * Optional object for the styles of the SideBar
+   */
+  style?: React.CSSProperties
 }
 
 const SideBar = ({
@@ -118,6 +122,7 @@ const SideBar = ({
   isLoadingHeaderInfo,
   isLoadingSideBarList,
   numSkeletons = 5,
+  style,
   ...props
 }: SideBarProps) => {
   const sidebarRef: MutableRefObject<HTMLDivElement | null> =
@@ -129,11 +134,8 @@ const SideBar = ({
     sideBarList
   )
   const containerHeaderRef = useRef<HTMLDivElement>(null)
-  const [positionToggleSideBar, setPositionToggleSideBar] = useState({
-    top: 0,
-    left: 0
-  })
   const { size, isMobile } = useResize()
+  const isMdScreen = (size?.width ?? 0) <= 1024
 
   const toggleSubMenu = (menuItemIndex: number) => {
     if (!menuItems?.length) return
@@ -182,15 +184,6 @@ const SideBar = ({
     }
   }, [])
 
-  useEffect(() => {
-    const element = containerHeaderRef.current
-
-    if (element) {
-      const { left, top } = element.getBoundingClientRect()
-      setPositionToggleSideBar({ left, top })
-    }
-  }, [containerHeaderRef])
-
   return (
     <>
       {isMobile && (
@@ -207,6 +200,14 @@ const SideBar = ({
         />
       )}
 
+      {!expand && isMdScreen && (
+        <ToggleSideBar
+          expand={expand}
+          className="block lg:hidden mt-3"
+          setExpand={setExpand}
+        />
+      )}
+
       <div
         ref={sidebarRef}
         role="container-sidebar"
@@ -219,7 +220,8 @@ const SideBar = ({
         style={{
           maxHeight: `calc(100vh - ${sidebarRef.current?.offsetTop}px)`,
           top: top ?? 0,
-          left: left ?? 0
+          left: left ?? 0,
+          ...style
         }}
       >
         <Flex
@@ -235,12 +237,9 @@ const SideBar = ({
             className={composeClasses('w-full h-16 mb-1', expand && 'relative')}
             ref={containerHeaderRef}
           >
-            <ToggleSideBar
-              expand={expand}
-              setExpand={setExpand}
-              postiton={positionToggleSideBar}
-              size={size}
-            />
+            {(!isMdScreen || expand) && (
+              <ToggleSideBar expand={expand} setExpand={setExpand} />
+            )}
             {expand && (
               <Flex
                 justifyContent="center"

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -6,7 +6,8 @@ import {
   useRef,
   useState
 } from 'react'
-import { ExclamationIcon, ChevronLeftIcon } from '@heroicons/react/outline'
+import ExclamationIcon from '@heroicons/react/outline/ExclamationIcon'
+import useResize from 'hooks/useResize'
 import { composeClasses } from 'lib/classes'
 import Text from '../Typography'
 import ToolTipHover from '../ToolTipHover'
@@ -14,6 +15,7 @@ import Flex from '../Layout/Flex/Flex'
 import SideBarHeader from './SideBarHeader'
 import SideBarItem from './SideBarItem'
 import SkeletonSideBarList from './SkeletonSideBarList'
+import ToggleSideBar from './ToggleSideBar'
 import './sideBar.css'
 
 export interface SideBarSubItem {
@@ -126,6 +128,12 @@ const SideBar = ({
   const [menuItems, setMenuItems] = useState<SideBarList | undefined>(
     sideBarList
   )
+  const containerHeaderRef = useRef<HTMLDivElement>(null)
+  const [positionToggleSideBar, setPositionToggleSideBar] = useState({
+    top: 0,
+    left: 0
+  })
+  const { size, isMobile } = useResize()
 
   const toggleSubMenu = (menuItemIndex: number) => {
     if (!menuItems?.length) return
@@ -174,140 +182,155 @@ const SideBar = ({
     }
   }, [])
 
+  useEffect(() => {
+    const element = containerHeaderRef.current
+
+    if (element) {
+      const { left, top } = element.getBoundingClientRect()
+      setPositionToggleSideBar({ left, top })
+    }
+  }, [containerHeaderRef])
+
   return (
-    <div
-      ref={sidebarRef}
-      role="container-sidebar"
-      className={composeClasses(
-        'bg-gray-50 border-t-0 box-border overflow-hidden h-full relative border',
-        'transition-all delay-75 duration-200 ease-in',
-        expand ? 'w-60 min-w-full' : 'w-0 lg:w-14.5 lg:min-w-14.5'
+    <>
+      {isMobile && (
+        <div
+          className={composeClasses(
+            'lg:hidden absolute z-40 transition-all duration-200 ease-in',
+            expand ? 'fade-in w-full h-full opacity-90' : 'fade-out opacity-0'
+          )}
+          style={{
+            backgroundColor: 'rgba(17, 24, 39, 0.75)',
+            top: top ?? 0,
+            left: left ?? 0
+          }}
+        />
       )}
-      style={{
-        maxHeight: `calc(100vh - ${sidebarRef.current?.offsetTop}px)`,
-        top: top ?? 0,
-        left: left ?? 0
-      }}
-    >
-      <Flex className="h-full flex-col transition-all delay-300 ease-out">
+
+      <div
+        ref={sidebarRef}
+        role="container-sidebar"
+        className={composeClasses(
+          'border-t-0 box-border overflow-hidden h-full border',
+          'transition-all delay-75 duration-200 ease-in',
+          expand ? 'w-60 min-w-full' : 'w-0 lg:w-14.5 lg:min-w-14.5',
+          isMobile ? 'absolute z-50' : 'relative'
+        )}
+        style={{
+          maxHeight: `calc(100vh - ${sidebarRef.current?.offsetTop}px)`,
+          top: top ?? 0,
+          left: left ?? 0
+        }}
+      >
         <Flex
-          justifyContent="between"
-          alignItems="center"
-          className={composeClasses('w-full h-16 mb-1', expand && 'relative')}
+          className="h-full flex-col transition-all delay-300 ease-out bg-gray-50"
+          style={{
+            maxWidth: 240
+          }}
         >
-          <div
-            role="active-sidebar"
-            className={composeClasses(
-              'fixed mx-2 border rounded-full bg-white text-primary cursor-pointer transition-all duration-300 ease-in-out',
-              'focus:bg-primary focus:text-white',
-              'hover:bg-blue-50',
-              expand && 'absolute right-2'
-            )}
-            onClick={() => setExpand(!expand)}
+          <Flex
+            role="container-header"
+            justifyContent="between"
+            alignItems="center"
+            className={composeClasses('w-full h-16 mb-1', expand && 'relative')}
+            ref={containerHeaderRef}
           >
-            <Flex
-              justifyContent="center"
-              alignItems="center"
-              className={composeClasses(
-                'w-9 h-9 transform transition-all duration-200 ease-in-out',
-                expand ? 'rotate-0' : 'rotate-180'
-              )}
-            >
-              <ChevronLeftIcon
-                className="transition-all duration-200 ease-in-out"
-                width={18}
-              />
-            </Flex>
+            <ToggleSideBar
+              expand={expand}
+              setExpand={setExpand}
+              postiton={positionToggleSideBar}
+              size={size}
+            />
+            {expand && (
+              <Flex
+                justifyContent="center"
+                gap="1"
+                className="flex-col col-span-2 p-3 w-full"
+              >
+                <SideBarHeader
+                  sideBarName={sideBarName}
+                  sideBarSubTitle={sideBarSubTitle}
+                  isLoadingHeaderInfo={isLoadingHeaderInfo}
+                />
+              </Flex>
+            )}
+          </Flex>
+          <div
+            role="list-options"
+            className={`${
+              !expand ? 'hide-scroll' : ''
+            } overflow-y-auto overflow-x-hidden flex-grow mx-2`}
+          >
+            {isLoadingSideBarList ? (
+              <SkeletonSideBarList childs={numSkeletons} />
+            ) : (
+              menuItems?.map(
+                (item, index: number) =>
+                  !item.hidden && (
+                    <SideBarItem
+                      key={`${item.title}-${index.toString()}`}
+                      index={index}
+                      disabledOptionsTag={disabledOptionsTag}
+                      isOptionClicked={isOptionClicked}
+                      isExpand={expand}
+                      handleClickOption={handleClickOption}
+                      toggleSubMenu={toggleSubMenu}
+                      {...item}
+                    />
+                  )
+              )
+            )}
           </div>
-          {expand && (
+          {props.dangerZone?.show && (
             <Flex
-              justifyContent="center"
-              gap="1"
-              className="flex-col col-span-2 p-3 w-full"
+              role="danger-zone"
+              alignItems="center"
+              className="w-full cursor-pointer group mb-4"
+              onClick={() => {
+                if (props.dangerZone?.callBack) {
+                  flushSync
+                    ? flushSync(() => setIsOptionClicked(true))
+                    : setIsOptionClicked(true)
+                  props.dangerZone?.callBack()
+                }
+              }}
             >
-              <SideBarHeader
-                sideBarName={sideBarName}
-                sideBarSubTitle={sideBarSubTitle}
-                isLoadingHeaderInfo={isLoadingHeaderInfo}
-              />
+              <ToolTipHover
+                variantPopup="dark"
+                disabled={expand || isOptionClicked}
+                complementPosition={{ top: 30, left: 85 }}
+                element={
+                  <Flex
+                    justifyContent="center"
+                    alignItems="center"
+                    className="w-14"
+                  >
+                    <ExclamationIcon
+                      role="danger-zone-icon"
+                      width={25}
+                      className={composeClasses(
+                        props.dangerZone?.active ? 'text-white' : 'text-error'
+                      )}
+                    />
+                  </Flex>
+                }
+              >
+                {props?.dangerZone?.text}
+              </ToolTipHover>
+              <Text
+                size="sm"
+                className={composeClasses(
+                  'min-w-max',
+                  props.dangerZone?.active ? 'text-white' : 'text-info'
+                )}
+              >
+                {props?.dangerZone?.text}
+              </Text>
             </Flex>
           )}
         </Flex>
-        <div
-          role="list-options"
-          className={`${
-            !expand ? 'hide-scroll' : ''
-          } overflow-y-auto overflow-x-hidden flex-grow mx-2`}
-        >
-          {isLoadingSideBarList ? (
-            <SkeletonSideBarList childs={numSkeletons} />
-          ) : (
-            menuItems?.map(
-              (item, index: number) =>
-                !item.hidden && (
-                  <SideBarItem
-                    key={`${item.title}-${index.toString()}`}
-                    index={index}
-                    disabledOptionsTag={disabledOptionsTag}
-                    isOptionClicked={isOptionClicked}
-                    isExpand={expand}
-                    handleClickOption={handleClickOption}
-                    toggleSubMenu={toggleSubMenu}
-                    {...item}
-                  />
-                )
-            )
-          )}
-        </div>
-        {props.dangerZone?.show && (
-          <Flex
-            role="danger-zone"
-            alignItems="center"
-            className="w-full cursor-pointer group mb-4"
-            onClick={() => {
-              if (props.dangerZone?.callBack) {
-                flushSync
-                  ? flushSync(() => setIsOptionClicked(true))
-                  : setIsOptionClicked(true)
-                props.dangerZone?.callBack()
-              }
-            }}
-          >
-            <ToolTipHover
-              variantPopup="dark"
-              disabled={expand || isOptionClicked}
-              complementPosition={{ top: 30, left: 85 }}
-              element={
-                <Flex
-                  justifyContent="center"
-                  alignItems="center"
-                  className="w-14"
-                >
-                  <ExclamationIcon
-                    role="danger-zone-icon"
-                    width={25}
-                    className={composeClasses(
-                      props.dangerZone?.active ? 'text-white' : 'text-error'
-                    )}
-                  />
-                </Flex>
-              }
-            >
-              {props?.dangerZone?.text}
-            </ToolTipHover>
-            <Text
-              size="sm"
-              className={composeClasses(
-                'min-w-max',
-                props.dangerZone?.active ? 'text-white' : 'text-info'
-              )}
-            >
-              {props?.dangerZone?.text}
-            </Text>
-          </Flex>
-        )}
-      </Flex>
-    </div>
+      </div>
+    </>
   )
 }
 

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -1,4 +1,5 @@
 import {
+  CSSProperties,
   MutableRefObject,
   ReactElement,
   ReactNode,
@@ -107,7 +108,7 @@ export interface SideBarProps {
   /**
    * Optional object for the styles of the SideBar
    */
-  style?: React.CSSProperties
+  style?: CSSProperties
 }
 
 const SideBar = ({
@@ -123,7 +124,7 @@ const SideBar = ({
   isLoadingSideBarList,
   numSkeletons = 5,
   style,
-  ...props
+  dangerZone
 }: SideBarProps) => {
   const sidebarRef: MutableRefObject<HTMLDivElement | null> =
     useRef<HTMLDivElement>(null)
@@ -134,8 +135,7 @@ const SideBar = ({
     sideBarList
   )
   const containerHeaderRef = useRef<HTMLDivElement>(null)
-  const { size, isMobile } = useResize()
-  const isMdScreen = (size?.width ?? 0) <= 1024
+  const { isMobile, isMdScreen } = useResize()
 
   const toggleSubMenu = (menuItemIndex: number) => {
     if (!menuItems?.length) return
@@ -280,17 +280,17 @@ const SideBar = ({
               )
             )}
           </div>
-          {props.dangerZone?.show && (
+          {dangerZone?.show && (
             <Flex
               role="danger-zone"
               alignItems="center"
               className="w-full cursor-pointer group mb-4"
               onClick={() => {
-                if (props.dangerZone?.callBack) {
+                if (dangerZone?.callBack) {
                   flushSync
                     ? flushSync(() => setIsOptionClicked(true))
                     : setIsOptionClicked(true)
-                  props.dangerZone?.callBack()
+                  dangerZone?.callBack()
                 }
               }}
             >
@@ -308,22 +308,22 @@ const SideBar = ({
                       role="danger-zone-icon"
                       width={25}
                       className={composeClasses(
-                        props.dangerZone?.active ? 'text-white' : 'text-error'
+                        dangerZone?.active ? 'text-white' : 'text-error'
                       )}
                     />
                   </Flex>
                 }
               >
-                {props?.dangerZone?.text}
+                {dangerZone?.text}
               </ToolTipHover>
               <Text
                 size="sm"
                 className={composeClasses(
                   'min-w-max',
-                  props.dangerZone?.active ? 'text-white' : 'text-info'
+                  dangerZone?.active ? 'text-white' : 'text-info'
                 )}
               >
-                {props?.dangerZone?.text}
+                {dangerZone?.text}
               </Text>
             </Flex>
           )}

--- a/src/components/SideBar/SideBarHeader.tsx
+++ b/src/components/SideBar/SideBarHeader.tsx
@@ -40,12 +40,9 @@ const SideBarHeader = ({
             variant="span"
             size="base"
             bold
-            className="block w-52 letter-spacing-negative capitalize max-h-11 overflow-hidden overflow-ellipsis"
+            className="block w-52 letter-spacing-negative capitalize max-h-11 whitespace-nowrap overflow-hidden overflow-ellipsis"
             style={{
-              display: '-webkit-box',
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: 'vertical',
-              maxWidth: 181
+              maxWidth: 160
             }}
           >
             {sideBarName}

--- a/src/components/SideBar/ToggleSideBar.tsx
+++ b/src/components/SideBar/ToggleSideBar.tsx
@@ -1,43 +1,39 @@
+import { Dispatch } from 'react'
 import { ChevronLeftIcon } from '@heroicons/react/outline'
-import { SizeTypes } from 'hooks/useResize'
 import { composeClasses } from 'lib/classes'
 import Flex from '../Layout/Flex/Flex'
 
+interface ToggleSideBarProps {
+  /**
+   * Indicates if the sidebar is expanded
+   */
+  expand: boolean
+  /**
+   * Class to be applied to the component
+   */
+  className?: string
+  /**
+   * Function to set the expand state
+   */
+  setExpand: Dispatch<React.SetStateAction<boolean>>
+}
+
 const ToggleSideBar = ({
   expand,
-  setExpand,
-  postiton,
-  size
-}: {
-  expand: boolean
-  setExpand: (expand: boolean) => void
-  size: SizeTypes
-  postiton: {
-    top: number
-    left: number
-  }
-}) => {
-  const isHidden = (size?.width ?? 0) <= 1024
-  console.log(postiton)
-
+  className,
+  setExpand
+}: ToggleSideBarProps) => {
   return (
     <div
       role="active-sidebar"
       className={composeClasses(
-        'fixed lg:absolute mx-2 border rounded-full bg-white text-primary cursor-pointer transition-all duration-300 ease-in-out',
+        'absolute mx-2 border rounded-full bg-white text-primary cursor-pointer transition-all duration-300 ease-in-out',
         'focus:bg-primary focus:text-white',
         'hover:bg-blue-50',
-        expand && 'absolute right-2'
+        expand && 'right-2',
+        className
       )}
-      onClick={() => setExpand(!expand)}
-      style={
-        isHidden && !expand
-          ? {
-              top: postiton.top + 12,
-              left: postiton.left
-            }
-          : undefined
-      }
+      onClick={() => setExpand((prev) => !prev)}
     >
       <Flex
         justifyContent="center"

--- a/src/components/SideBar/ToggleSideBar.tsx
+++ b/src/components/SideBar/ToggleSideBar.tsx
@@ -1,0 +1,59 @@
+import { ChevronLeftIcon } from '@heroicons/react/outline'
+import { SizeTypes } from 'hooks/useResize'
+import { composeClasses } from 'lib/classes'
+import Flex from '../Layout/Flex/Flex'
+
+const ToggleSideBar = ({
+  expand,
+  setExpand,
+  postiton,
+  size
+}: {
+  expand: boolean
+  setExpand: (expand: boolean) => void
+  size: SizeTypes
+  postiton: {
+    top: number
+    left: number
+  }
+}) => {
+  const isHidden = (size?.width ?? 0) <= 1024
+  console.log(postiton)
+
+  return (
+    <div
+      role="active-sidebar"
+      className={composeClasses(
+        'fixed lg:absolute mx-2 border rounded-full bg-white text-primary cursor-pointer transition-all duration-300 ease-in-out',
+        'focus:bg-primary focus:text-white',
+        'hover:bg-blue-50',
+        expand && 'absolute right-2'
+      )}
+      onClick={() => setExpand(!expand)}
+      style={
+        isHidden && !expand
+          ? {
+              top: postiton.top + 12,
+              left: postiton.left
+            }
+          : undefined
+      }
+    >
+      <Flex
+        justifyContent="center"
+        alignItems="center"
+        className={composeClasses(
+          'w-9 h-9 transform transition-all duration-200 ease-in-out',
+          expand ? 'rotate-0' : 'rotate-180'
+        )}
+      >
+        <ChevronLeftIcon
+          className="transition-all duration-200 ease-in-out"
+          width={18}
+        />
+      </Flex>
+    </div>
+  )
+}
+
+export default ToggleSideBar

--- a/src/hooks/useResize.ts
+++ b/src/hooks/useResize.ts
@@ -8,6 +8,7 @@ export type SizeTypes = {
 export type useResizeReturnedTypes = {
   size: SizeTypes
   isMobile: boolean
+  isMdScreen: boolean
 }
 
 /**
@@ -42,5 +43,9 @@ export default function useResize(): useResizeReturnedTypes {
     return () => window.removeEventListener('resize', handleChangeResize)
   }, [])
 
-  return { size, isMobile: window.innerWidth < 768 }
+  return {
+    size,
+    isMobile: window.innerWidth < 768,
+    isMdScreen: window.innerWidth <= 1024
+  }
 }

--- a/src/stories/SideBar.stories.tsx
+++ b/src/stories/SideBar.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { ComponentStory, ComponentMeta } from '@storybook/react'
-import SideBarComponent from '../components/SideBar/SideBar'
 import { HomeIcon } from '@heroicons/react/outline'
-import { ExclamationIcon } from '@heroicons/react/solid'
+import ExclamationIcon from '@heroicons/react/solid/ExclamationIcon'
+import SideBarComponent from '../components/SideBar/SideBar'
 import Flex from '../components/Layout/Flex'
 
 export default {


### PR DESCRIPTION
## Summary

- For mobile devices, the sidebar will overlay the content.
- For mobile, the button to hide or show the sidebar will be positioned with the reference of its container element.


## Task

[CD-1215](https://dd360.atlassian.net/browse/CD-1215)


## Affected sections

- src/components/SideBar/SideBar.tsx
- src/components/SideBar/ToggleSideBar.tsx
- src/stories/SideBar.stories.tsx

## How did you test this change?

All test passed ✅
