### PR TITLE
fix(Sidebar): Add validation in SideBarItem

### DIFF
--- a/src/components/SideBar/SideBarItem.tsx
+++ b/src/components/SideBar/SideBarItem.tsx
@@ -136,8 +136,7 @@ const SideBarItem = ({
         )}
         onClick={handleClickOption(
           disabled,
-           subItemsArray?.length && isExpand ? () => toggleSubMenu(index) : goTo
-
+          subItemsArray?.length && isExpand ? () => toggleSubMenu(index) : goTo
         )}
       >
         <ToolTipHover

--- a/src/components/SideBar/SideBarItem.tsx
+++ b/src/components/SideBar/SideBarItem.tsx
@@ -136,7 +136,8 @@ const SideBarItem = ({
         )}
         onClick={handleClickOption(
           disabled,
-          subItemsArray?.length ? () => toggleSubMenu(index) : goTo
+           subItemsArray?.length && isExpand ? () => toggleSubMenu(index) : goTo
+
         )}
       >
         <ToolTipHover


### PR DESCRIPTION
Add validation in SideBarItem

## Summary

A validation was added, so that in the event that the sidebar is not expanded, when clicking on an item that has subitems, it allows us to be redirected correctly

## Task

- [Sidebar](https://dd360.atlassian.net/jira/software/c/projects/CD/boards/12?modal=detail&selectedIssue=CD-1340&assignee=6397d027fbf54baf29036449)


## Affected sections

- src/components/SideBar/SideBarItem.tsx

## How did you test this change?

- Mannualy 
- All tests was passed ✅
